### PR TITLE
Resolve issues with random start times and concurrency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     },
     "dependencies": {
         "axios": "^0.21.1",
+        "bluebird": "^3.7.2",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "lodash": "^4.17.21",
         "luxon": "^2.0.2"
     },
     "devDependencies": {
+        "@types/bluebird": "^3.5.36",
         "@types/express": "^4.17.13",
         "@types/lodash": "^4.14.172",
         "@types/luxon": "^2.0.1",
@@ -62,7 +64,7 @@
                 4
             ],
             "@typescript-eslint/no-unused-vars": [
-                "error", 
+                "error",
                 {
                     "argsIgnorePattern": "^_"
                 }

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -31,22 +31,22 @@ export const post = async (
 
         const { startDate, endDate } = getStartAndEndDates(period);
         const worklogs = await getWorklogs(sourceAccountId, sourceToken, startDate, endDate);
-        const fetchedCount = worklogs.length;
+        const extractedCount = worklogs.length;
 
-        if (!fetchedCount) {
+        if (!extractedCount) {
             throw new HttpException('There are no worklogs to copy. Please choose a different time period.', 406);
         }
 
-        const worklogsForLoad = getTransformedWorklogs(worklogs, destinationAccountId, destinationIssueKey, description);
+        const transformedWorklogs = getTransformedWorklogs(worklogs, destinationAccountId, destinationIssueKey, description);
         
-        const responses = await loadWorklogs(worklogsForLoad, destinationToken);
-        const createdCount = responses.filter(({ status }) => status === 200).length;
+        const responses = await loadWorklogs(transformedWorklogs, destinationToken);
+        const loadedCount = responses.filter(({ status }) => status === 200).length;
 
         response.json({
             status: 200,
             message: 'Success!',
-            fetched: fetchedCount,
-            created: createdCount
+            extracted: extractedCount,
+            loaded: loadedCount
         });
     } catch(error) {
         next(error);

--- a/src/utils/etl.ts
+++ b/src/utils/etl.ts
@@ -1,8 +1,10 @@
 import axios, { AxiosResponse } from 'axios';
-import { Worklog, GetWorklogsResponse, NewWorklog } from 'src/types';
+import { Promise } from 'bluebird';
 import { groupBy } from 'lodash';
 import HttpException from 'src/exceptions/HttpException';
+import { Worklog, GetWorklogsResponse, NewWorklog } from 'src/types';
 
+const MAX_CONCURRENT_REQUESTS = 12;
 const BASE_URL = process.env.TEMPO_REST_API_ENDPOINT;
 
 if (!BASE_URL) {
@@ -20,30 +22,37 @@ export const getWorklogs = async (
             `${ BASE_URL }/user/${ accountId }?from=${ startDate }&to=${ endDate }&limit=1000`, 
             { headers: { Authorization: `Bearer ${ token }` } }
         );
-    
+
         return results;
     } catch (error) {
-        throw new HttpException('Error fetching worklogs.');
+        throw new HttpException('Error extracting worklogs.');
     }
 };
 
+/**
+ * Using bluebird library to handle worklog loading.
+ * Tempo API doesn't have an endpoint for creating worklogs in bulk and has a limit for concurrent requests. 
+ * If we don't set a limit, promise is rejected and we get a "429 Too Many Requests" response.
+ * https://community.atlassian.com/t5/Jira-Service-Management/Rate-Limit-Too-Many-Requests/qaq-p/1020846
+ * 
+ * @param worklogs 
+ * @param token 
+ * @returns a promise that is resolved with an array of axios responses
+ */
 export const loadWorklogs = async (
     worklogs: NewWorklog[], 
     token: string
 ): Promise<AxiosResponse[]> => {
     try {
-        return await Promise.all(worklogs.map(
-            (worklog) => axios.post(
-                `${ BASE_URL }`, 
-                worklog,
-                { headers: { Authorization: `Bearer ${ token }` } }
-            )
-        ));
+        return await Promise.map(worklogs, (worklog) => axios.post(
+            BASE_URL, 
+            worklog,
+            { headers: { Authorization: `Bearer ${ token }` } }
+        ), { concurrency: MAX_CONCURRENT_REQUESTS });
     } catch(error) {
         throw new HttpException('Error creating new worklogs.');
     }
 };
-
 
 export const getTransformedWorklogs = (
     worklogs: Worklog[], 
@@ -56,7 +65,7 @@ export const getTransformedWorklogs = (
     return Object.values(grouped).map((worklogsGroupedByDay) => {
         return worklogsGroupedByDay.reduce((prev, curr) => {
             const { timeSpentSeconds: prevTimeSpentSeconds, billableSeconds: prevBillableSeconds } = prev;
-            const { timeSpentSeconds, billableSeconds, startDate, startTime  } = curr;
+            const { timeSpentSeconds, billableSeconds, startDate } = curr;
 
             return {
                 issueKey,
@@ -64,7 +73,7 @@ export const getTransformedWorklogs = (
                 timeSpentSeconds: prevTimeSpentSeconds + timeSpentSeconds,
                 billableSeconds: prevBillableSeconds + billableSeconds,
                 startDate,
-                startTime,
+                startTime: '08:00:00',
                 description
             };
         }, { timeSpentSeconds: 0, billableSeconds: 0 } as NewWorklog);

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,6 +117,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@types/bluebird@^3.5.36":
+  version "3.5.36"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.36.tgz#00d9301d4dc35c2f6465a8aec634bb533674c652"
+  integrity sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==
+
 "@types/body-parser@*":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
@@ -428,6 +433,11 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 body-parser@1.19.0:
   version "1.19.0"


### PR DESCRIPTION
* Resolve an issue with random start times for created worklogs
* Resolve '429 Too Many Requests' error when creating worklogs for the whole month